### PR TITLE
OP#7077 Fix multimoneda en diferencia de cambio y tasa de factura

### DIFF
--- a/base/src/org/openXpertya/model/AllocationGenerator.java
+++ b/base/src/org/openXpertya/model/AllocationGenerator.java
@@ -1949,6 +1949,8 @@ public class AllocationGenerator {
 		 * Oct - 24
 		 * dREHER
 		 */
+		MCintoloExchangeDifSettings exchangeDifSettings = getActiveExchangeDifSettings();
+		
 		MInvoice inv = null;
 		int invoiceID = 0;
 		if(getBPartner().isCintolo_Acumulate_Exchange_Dif()) {
@@ -1966,10 +1968,10 @@ public class AllocationGenerator {
 			if(invoiceID < 0) invoiceID = 0;
 		}
 		
-		if(invoiceID > 0) 
+		if(invoiceID > 0)
 			inv = new MInvoice(getCtx(), invoiceID, getTrxName());
 		else // Se crea la cabecera de la invoice
-			inv = createCreditDebitInvoiceForExchangeDif(isCredit, isFiscal, isForCurrentAccount);
+			inv = createCreditDebitInvoiceForExchangeDif(isCredit, isFiscal, isForCurrentAccount, exchangeDifSettings);
 		
 		// Si estoy creando una nueva factura, configurar todos los campos correspondientes
 		if(invoiceID == 0) {
@@ -1978,7 +1980,11 @@ public class AllocationGenerator {
 			inv.setFechadeTCparaActualizarPrecios(Env.getDate(getCtx())); // dREHER sep 24
 			inv.setApplyPercepcion(false);
 
-			int priceListID = DB.getSQLValue(trxName, "SELECT " + (isCredit? " Credit_PriceList " : " Debit_PriceList ") +" FROM C_Cintolo_Exchange_Dif_Settings ORDER BY created DESC LIMIT 1");
+			int priceListID = isCredit? exchangeDifSettings.getCredit_PriceList() : exchangeDifSettings.getDebit_PriceList();
+			if(priceListID <= 0) {
+				throw new Exception("La configuración activa de diferencia de cambio no tiene tarifa "
+						+ (isCredit? "de crédito" : "de débito") + " válida");
+			}
 			inv.setM_PriceList_ID(priceListID);
 			inv.setC_Currency_ID(PESOS_ARG);
 
@@ -2009,13 +2015,8 @@ public class AllocationGenerator {
 		}
 		
 		// Se crea la invoiceLine 		
-		int productID = DB.getSQLValue(trxName, "SELECT M_Product_ID FROM C_Cintolo_Exchange_Dif_Settings ORDER BY created DESC LIMIT 1");
-		MProduct product = new MProduct(getCtx(), productID, getTrxName());
-		
-		List<MTax> taxes = MTax.getOfTaxCategory(getCtx(), product.getC_TaxCategory_ID(), getTrxName());
-		if (taxes==null || taxes.size()==0)
-			throw new Exception("No existe un impuesto para la categoria de impuesto definido en el artículo " + product.getValue());
-		MTax tax = taxes.get(0); 
+		MProduct product = getExchangeDifProduct(exchangeDifSettings);
+		MTax tax = getExchangeDifTax(product);
 		
 		
 		/**
@@ -2310,7 +2311,8 @@ public class AllocationGenerator {
 	 * @return factura creada
 	 * @throws Exception en caso de error
 	 */
-	protected MInvoice createCreditDebitInvoiceForExchangeDif(boolean isCredit, boolean isFiscal, boolean isForCurrentAccount) throws Exception{
+	protected MInvoice createCreditDebitInvoiceForExchangeDif(boolean isCredit, boolean isFiscal, boolean isForCurrentAccount,
+			MCintoloExchangeDifSettings exchangeDifSettings) throws Exception{
 		
 		MInvoice invoice = new MInvoice(getCtx(), 0, getTrxName());
 		MBPartner bPartner = getBPartner();
@@ -2332,8 +2334,13 @@ public class AllocationGenerator {
 			ptoVenta = (bPartner.get_Value("Cintolo_Point_Of_Sale")!=null? (Integer)bPartner.get_Value("Cintolo_Point_Of_Sale")
 					:0);
 			
-			if(ptoVenta <= 0)
-				ptoVenta = DB.getSQLValue(trxName, " SELECT point_of_sale FROM C_Cintolo_Exchange_Dif_Settings ORDER BY created DESC LIMIT 1");
+			if(ptoVenta <= 0) {
+				ptoVenta = exchangeDifSettings.getPoint_Of_Sale();
+			}
+			
+			if(ptoVenta <= 0) {
+				throw new Exception("La configuración activa de diferencia de cambio no tiene punto de venta válido");
+			}
 			
 			invoice = setDocType(invoice, isCredit, ptoVenta);
 			if(LOCALE_AR_ACTIVE){
@@ -2341,7 +2348,10 @@ public class AllocationGenerator {
 			}
 			
 		} else {
-			int docTypeID = DB.getSQLValue(trxName, "SELECT C_DocType_ID FROM C_Cintolo_Exchange_Dif_Settings ORDER BY created DESC LIMIT 1");
+			int docTypeID = exchangeDifSettings.getC_DocType_ID();
+			if(docTypeID <= 0) {
+				throw new Exception("La configuración activa de diferencia de cambio no tiene tipo de comprobante válido");
+			}
 			invoice.setC_DocTypeTarget_ID(docTypeID);				
 		}
 		
@@ -2476,7 +2486,107 @@ public class AllocationGenerator {
 		if (!pl.isTaxIncluded())
 			throw new Exception("La tarifa configurada " + pl.getName() + " para diferencia de cambio debe tener activado el check impuestos incluidos en el precio.");
 		
-		return priceList; 
+		return priceList;
+	}
+
+	/**
+	 * Obtiene la configuración activa para diferencias de cambio.
+	 */
+	protected MCintoloExchangeDifSettings getActiveExchangeDifSettings() throws Exception {
+		int adClientID = Env.getAD_Client_ID(getCtx());
+		int settingsID = DB.getSQLValue(getTrxName(),
+				"SELECT C_Cintolo_Exchange_Dif_Settings_ID "
+				+ "FROM C_Cintolo_Exchange_Dif_Settings "
+				+ "WHERE IsActive='Y' AND AD_Client_ID = ? "
+				+ "ORDER BY Created DESC "
+				+ "LIMIT 1",
+				adClientID);
+		
+		// Fallback global (cliente 0) activo
+		if(settingsID <= 0) {
+			settingsID = DB.getSQLValue(getTrxName(),
+					"SELECT C_Cintolo_Exchange_Dif_Settings_ID "
+					+ "FROM C_Cintolo_Exchange_Dif_Settings "
+					+ "WHERE IsActive='Y' AND AD_Client_ID = 0 "
+					+ "ORDER BY Created DESC "
+					+ "LIMIT 1");
+		}
+		
+		// Compatibilidad: tomar cualquier registro activo
+		if(settingsID <= 0) {
+			settingsID = DB.getSQLValue(getTrxName(),
+					"SELECT C_Cintolo_Exchange_Dif_Settings_ID "
+					+ "FROM C_Cintolo_Exchange_Dif_Settings "
+					+ "WHERE IsActive='Y' "
+					+ "ORDER BY Created DESC "
+					+ "LIMIT 1");
+		}
+		
+		// Compatibilidad legacy: si no hay ninguna activa, tomar la última configuración cargada
+		if(settingsID <= 0) {
+			settingsID = DB.getSQLValue(getTrxName(),
+					"SELECT C_Cintolo_Exchange_Dif_Settings_ID "
+					+ "FROM C_Cintolo_Exchange_Dif_Settings "
+					+ "ORDER BY Created DESC "
+					+ "LIMIT 1");
+		}
+		
+		if(settingsID <= 0) {
+			throw new Exception("No existe una configuración activa de diferencia de cambio (C_Cintolo_Exchange_Dif_Settings)");
+		}
+		
+		MCintoloExchangeDifSettings settings = new MCintoloExchangeDifSettings(getCtx(), settingsID, getTrxName());
+		if(settings.getID() <= 0) {
+			throw new Exception("No se pudo cargar la configuración activa de diferencia de cambio. ID=" + settingsID);
+		}
+		
+		return settings;
+	}
+	
+	/**
+	 * Retorna el producto configurado para diferencias de cambio.
+	 */
+	protected MProduct getExchangeDifProduct(MCintoloExchangeDifSettings settings) throws Exception {
+		int productID = settings.getM_Product_ID();
+		if(productID <= 0) {
+			throw new Exception("La configuración activa de diferencia de cambio no tiene producto configurado (M_Product_ID)");
+		}
+		
+		MProduct product = new MProduct(getCtx(), productID, getTrxName());
+		if(product.getID() <= 0) {
+			throw new Exception("No existe el producto configurado para diferencia de cambio. M_Product_ID=" + productID);
+		}
+		
+		return product;
+	}
+	
+	/**
+	 * Retorna el impuesto activo asociado a la categoría del producto de diferencia de cambio.
+	 */
+	protected MTax getExchangeDifTax(MProduct product) throws Exception {
+		int taxCategoryID = product.getC_TaxCategory_ID();
+		if(taxCategoryID <= 0) {
+			throw new Exception("El producto de diferencia de cambio no tiene categoría de impuesto. M_Product_ID="
+					+ product.getID() + ", Value=" + product.getValue());
+		}
+		
+		List<MTax> taxes = MTax.getOfTaxCategory(getCtx(), taxCategoryID, getTrxName());
+		MTax tax = null;
+		if(taxes != null) {
+			for (MTax aTax : taxes) {
+				if(aTax != null && aTax.getID() > 0 && aTax.isActive()) {
+					tax = aTax;
+					break;
+				}
+			}
+		}
+		
+		if(tax == null) {
+			throw new Exception("No existe un impuesto activo para la categoría de impuesto del artículo "
+					+ product.getValue() + " (M_Product_ID=" + product.getID() + ", C_TaxCategory_ID=" + taxCategoryID + ")");
+		}
+		
+		return tax;
 	}
 	
 	/**

--- a/base/src/org/openXpertya/model/CalloutInvoiceExt.java
+++ b/base/src/org/openXpertya/model/CalloutInvoiceExt.java
@@ -205,6 +205,108 @@ public class CalloutInvoiceExt extends CalloutInvoice {
 		return "";
 	}
 	
+	/**
+	 * Actualiza la tasa de cambio de la factura según moneda/fecha seleccionada.
+	 * Si no existe cotización para ese día en moneda extranjera, advierte para carga manual
+	 * y evita que quede el valor por defecto 1.
+	 */
+	private String updateInvoiceExchangeRate(Properties ctx, int WindowNo, MTab mTab) {
+		if (isCalloutActive()) {
+			return "";
+		}
+		
+		setCalloutActive(true);
+		try {
+			int accountingCurrencyID = Env.getContextAsInt(ctx, "$C_Currency_ID");
+			if (accountingCurrencyID <= 0) {
+				return "";
+			}
+			Integer invoiceCurrencyID = getIntValue(mTab.getValue("C_Currency_ID"));
+			if (invoiceCurrencyID == null || invoiceCurrencyID <= 0) {
+				return "";
+			}
+			
+			// Si está en moneda contable, no aplica tasa manual de diferencia de cambio.
+			if (accountingCurrencyID > 0 && invoiceCurrencyID.intValue() == accountingCurrencyID) {
+				mTab.setValue("Cintolo_Exchange_Rate", null);
+				mTab.clearCurrentRecordWarning();
+				return "";
+			}
+			
+			Timestamp conversionDate = (Timestamp) mTab.getValue("DateAcct");
+			if (conversionDate == null) {
+				conversionDate = (Timestamp) mTab.getValue("DateInvoiced");
+			}
+			if (conversionDate == null) {
+				conversionDate = Env.getDate();
+			}
+			
+			Integer conversionTypeID = getIntValue(mTab.getValue("C_ConversionType_ID"));
+			if (conversionTypeID == null) {
+				conversionTypeID = 0;
+			}
+			
+			Integer orgID = getIntValue(mTab.getValue("AD_Org_ID"));
+			if (orgID == null || orgID <= 0) {
+				orgID = Env.getAD_Org_ID(ctx);
+			}
+			
+			BigDecimal conversionRate = MConversionRate.getRate(
+					invoiceCurrencyID,
+					accountingCurrencyID,
+					conversionDate,
+					conversionTypeID,
+					Env.getAD_Client_ID(ctx),
+					orgID);
+			
+			if (conversionRate != null && conversionRate.compareTo(Env.ZERO) > 0) {
+				// Siempre aplica la cotización vigente para evitar arrastre de valores anteriores.
+				mTab.setValue("Cintolo_Exchange_Rate", conversionRate);
+				mTab.clearCurrentRecordWarning();
+			} else {
+				// Si no hay cotización vigente, limpiar valor para exigir carga manual explícita.
+				mTab.setValue("Cintolo_Exchange_Rate", null);
+				mTab.setCurrentRecordWarning("No existe tasa de cambio para la fecha seleccionada. Debe completar manualmente la Tasa de Cambio de la factura.");
+			}
+			return "";
+		} finally {
+			setCalloutActive(false);
+		}
+	}
+	
+	private Integer getIntValue(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Integer) {
+			return (Integer)value;
+		}
+		if (value instanceof BigDecimal) {
+			return ((BigDecimal)value).intValue();
+		}
+		try {
+			return Integer.valueOf(value.toString());
+		} catch (Exception e) {
+			return null;
+		}
+	}
+	
+	public String C_Currency_ID(Properties ctx, int WindowNo, MTab mTab, MField mField, Object value) {
+		return updateInvoiceExchangeRate(ctx, WindowNo, mTab);
+	}
+	
+	public String DateInvoiced(Properties ctx, int WindowNo, MTab mTab, MField mField, Object value) {
+		return updateInvoiceExchangeRate(ctx, WindowNo, mTab);
+	}
+	
+	public String DateAcct(Properties ctx, int WindowNo, MTab mTab, MField mField, Object value) {
+		return updateInvoiceExchangeRate(ctx, WindowNo, mTab);
+	}
+	
+	public String C_ConversionType_ID(Properties ctx, int WindowNo, MTab mTab, MField mField, Object value) {
+		return updateInvoiceExchangeRate(ctx, WindowNo, mTab);
+	}
+	
 	
 	// dREHER Jun 25
 	private static int getConversionType(String tipo) {
@@ -410,7 +512,7 @@ public class CalloutInvoiceExt extends CalloutInvoice {
 
 		}
 
-		return "";
+		return updateInvoiceExchangeRate(ctx, WindowNo, tab);
 	}
 	
 	@Override
@@ -446,7 +548,8 @@ public class CalloutInvoiceExt extends CalloutInvoice {
 				
 			}
 		}
-		return ret;
+		String exchangeRateResult = updateInvoiceExchangeRate(ctx, WindowNo, tab);
+		return Util.isEmpty(ret, true) ? exchangeRateResult : ret;
 	}
 	
 	public String calloutCUIT(Properties ctx, int WindowNo, MTab mTab, MField mField, Object value) {
@@ -865,7 +968,7 @@ public class CalloutInvoiceExt extends CalloutInvoice {
 						.intValue(), pto);
 		}
 
-		return "";
+		return updateInvoiceExchangeRate(ctx, WindowNo, mTab);
     }    // bPartner
     
 	/**

--- a/base/src/org/openXpertya/model/MInvoice.java
+++ b/base/src/org/openXpertya/model/MInvoice.java
@@ -2253,6 +2253,12 @@ public class MInvoice extends X_C_Invoice implements DocAction, Authorization, C
 				setC_Currency_ID(Env.getContextAsInt(getCtx(), "#C_Currency_ID"));
 			}
 		}
+			
+		// Moneda extranjera: tomar cotización del día como default de la factura.
+		// Si no existe, obligar carga manual y evitar default 1.
+		if(!defaultInvoiceExchangeRate()) {
+			return false;
+		}
 
 		// Sales Rep
 
@@ -2941,6 +2947,79 @@ public class MInvoice extends X_C_Invoice implements DocAction, Authorization, C
 		currencyID = DB.getSQLValueEx(get_TrxName(), sql, new Object[] {string});
 		
 		return currencyID;
+	}
+	
+	/**
+	 * Para facturas en moneda distinta a la contable:
+	 * - Si existe cotización del día, la toma por defecto en Cintolo_Exchange_Rate.
+	 * - Si no existe, fuerza carga manual y evita persistir el default 1.
+	 */
+	private boolean defaultInvoiceExchangeRate() {
+		int accountingCurrencyID = Env.getContextAsInt(getCtx(), "$C_Currency_ID");
+		if (accountingCurrencyID <= 0
+				|| getC_Currency_ID() <= 0
+				|| getC_Currency_ID() == accountingCurrencyID) {
+			return true;
+		}
+		
+		BigDecimal currentRate = getInvoiceExchangeRate();
+		BigDecimal systemRate = MConversionRate.getRate(
+				getC_Currency_ID(),
+				accountingCurrencyID,
+				getExchangeRateLookupDate(),
+				getC_ConversionType_ID(),
+				getAD_Client_ID(),
+				getAD_Org_ID());
+		
+		if(systemRate != null && systemRate.compareTo(Env.ZERO) > 0) {
+			if(currentRate == null
+					|| currentRate.compareTo(Env.ZERO) <= 0
+					|| currentRate.compareTo(Env.ONE) == 0
+					|| !is_ValueChanged("Cintolo_Exchange_Rate")) {
+				set_ValueNoCheck("Cintolo_Exchange_Rate", systemRate);
+			}
+			return true;
+		}
+		
+		// Sin cotización del día: no dejar valor por defecto 1 en moneda extranjera.
+		if(!is_ValueChanged("Cintolo_Exchange_Rate")) {
+			set_ValueNoCheck("Cintolo_Exchange_Rate", null);
+			currentRate = null;
+		}
+		
+		if(currentRate == null
+				|| currentRate.compareTo(Env.ZERO) <= 0
+				|| currentRate.compareTo(Env.ONE) == 0) {
+			log.saveError("Error", "No existe tasa de cambio para la fecha seleccionada. Debe completar manualmente la Tasa de Cambio de la factura.");
+			return false;
+		}
+		
+		return true;
+	}
+	
+	private BigDecimal getInvoiceExchangeRate() {
+		Object exchangeRate = get_Value("Cintolo_Exchange_Rate");
+		if(exchangeRate == null) {
+			return null;
+		}
+		if(exchangeRate instanceof BigDecimal) {
+			return (BigDecimal)exchangeRate;
+		}
+		try {
+			return new BigDecimal(exchangeRate.toString());
+		} catch (Exception e) {
+			return null;
+		}
+	}
+	
+	private Timestamp getExchangeRateLookupDate() {
+		if(getDateAcct() != null) {
+			return new Timestamp(getFechaConversion().getTime());
+		}
+		if(getDateInvoiced() != null) {
+			return getDateInvoiced();
+		}
+		return Env.getDate();
 	}
 
 	/**
@@ -5312,18 +5391,18 @@ public class MInvoice extends X_C_Invoice implements DocAction, Authorization, C
 		// dREHER en el caso de facturas de proveedor y que se calcula todo en base a la
 		// tasa de cambio de la factura, se ajusta calculo del total convertido
 		BigDecimal invAmt = Env.ZERO;
-		;
 		if (!isSOTrx() && getFCProvTasaCambio()) {
-
-			if (getC_Currency_ID() != 118 && (get_Value("Cintolo_Exchange_Rate") == null
-					|| ((BigDecimal) get_Value("Cintolo_Exchange_Rate")).compareTo(Env.ZERO) == 0)) {
-
-				invAmt = getGrandTotal(true).multiply((BigDecimal) get_Value("Cintolo_Exchange_Rate"));
-
-			}
-			if (getC_Currency_ID() == 118)
+			int accountingCurrencyID = Env.getContextAsInt(getCtx(), "$C_Currency_ID");
+			BigDecimal invoiceExchangeRate = getInvoiceExchangeRate();
+			
+			if (getC_Currency_ID() == accountingCurrencyID) {
 				invAmt = getGrandTotal(true);
-
+			} else if (invoiceExchangeRate != null && invoiceExchangeRate.compareTo(Env.ZERO) > 0) {
+				invAmt = getGrandTotal(true).multiply(invoiceExchangeRate);
+			} else {
+				invAmt = MConversionRate.convertBase(getCtx(), getGrandTotal(true), // CM adjusted
+						getC_Currency_ID(), getDateAcct(), 0, getAD_Client_ID(), getAD_Org_ID());
+			}
 		} else {
 			invAmt = MConversionRate.convertBase(getCtx(), getGrandTotal(true), // CM adjusted
 					getC_Currency_ID(), getDateAcct(), 0, getAD_Client_ID(), getAD_Org_ID());


### PR DESCRIPTION
OP#7077
Fix multimoneda en diferencias de cambio:
- robustecimiento de generación de comprobantes por diferencia de cambio (configuración, producto e impuesto)
- autocompletado/validación de tasa de cambio en facturas en moneda extranjera
- advertencia y carga manual obligatoria cuando no existe cotización vigente para la fecha