### PR TITLE
OP#7098 Corregir retenciones en OP adelantada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 .classpath
 docs/
+.codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ El build usa **Apache Ant** invocado por scripts de shell. Se requiere Java 11 (
 cd utils_dev && ./Compilar.sh
 ```
 
+⚠️ **Regla operativa para agentes (obligatoria):**
+- Nunca intentar compilar el proyecto desde el agente.
+- Nunca ejecutar `Compilar.sh` (ni el de `utils_dev/` ni los de cada modulo).
+- Nunca ejecutar `ant` para build en este repositorio.
+- La compilacion la realiza exclusivamente el usuario de forma manual.
+
 `Compilar.sh` sourcea `VariablesCompilacion.sh` (define `JAVA_HOME`, `OXP_HOME`, `JJ_PASSWORD`, rutas de keystore, classpath con JARs de Ant) y ejecuta `ant clean && ant complete`.
 
 **Variables de entorno clave** (se pueden overridear antes de compilar):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ The build uses **Apache Ant** invoked via shell scripts. Java 11 (OpenJDK) is re
 cd utils_dev && ./Compilar.sh
 ```
 
+⚠️ **Mandatory operational rule for agents:**
+- Never try to compile this project from the agent.
+- Never run `Compilar.sh` (neither `utils_dev/Compilar.sh` nor module-level `Compilar.sh` scripts).
+- Never run `ant` for build tasks in this repository.
+- Compilation is performed manually by the user only.
+
 This sources `VariablesCompilacion.sh` (sets `JAVA_HOME`, `OXP_HOME`, `JJ_PASSWORD`, keystore paths, classpath with Ant JARs) then runs `ant clean && ant complete`.
 
 **Key environment variables** (override before building if needed):

--- a/client/Src/org/openXpertya/apps/form/VOrdenPagoModel.java
+++ b/client/Src/org/openXpertya/apps/form/VOrdenPagoModel.java
@@ -1553,6 +1553,11 @@ public class VOrdenPagoModel {
 	public void setPagoNormal(boolean pagoNormal, BigDecimal montoAnticipado) {
 		m_esPagoNormal = pagoNormal;
 		m_montoPagoAnticipado = montoAnticipado;
+		// En OP adelantada no corresponde mantener retenciones previamente calculadas.
+		if (!shouldManageRetentionsInCurrentPayment()) {
+			m_retenciones.clear();
+			retencionIncludedInMedioPago = false;
+		}
 	}
 
 	/**
@@ -1984,7 +1989,10 @@ public class VOrdenPagoModel {
 		// Actualización de información adicional del modelo
 		updateAditionalInfo();
 		// Calcula las retenciones a aplicarle a la entidad comercial
-		if (!isSOTrx() || m_retenciones == null || m_retenciones.size() == 0) {
+		if (!shouldManageRetentionsInCurrentPayment()) {
+			m_retenciones.clear();
+			retencionIncludedInMedioPago = false;
+		} else if (!isSOTrx() || m_retenciones == null || m_retenciones.size() == 0) {
 			/*
 			 * m_retGen = new GeneratorRetenciones(C_BPartner_ID,
 			 * facturasProcesar, manualAmounts, total, isSOTrx());
@@ -2675,14 +2683,20 @@ public class VOrdenPagoModel {
 				saveOk = false;
 				errorNo = PROCERROR_PAYMENTS_GENERATION;
 			} else {
-				// 4. Guardar Retenciones
-				m_retGen.setTrxName(get_TrxName()); // dREHER
-				m_retGen.setProjectID(getProjectID());
-				m_retGen.setCampaignID(getCampaignID());
-				m_retGen.save(hdr);
+				if (shouldManageRetentionsInCurrentPayment()) {
+					// 4. Guardar Retenciones
+					m_retGen.setTrxName(get_TrxName()); // dREHER
+					m_retGen.setProjectID(getProjectID());
+					m_retGen.setCampaignID(getCampaignID());
+					m_retGen.save(hdr);
 
-				// 5. Agregar retenciones como medio de pago
-				agregarRetencionesComoMediosPagos(pagos, hdr);
+					// 5. Agregar retenciones como medio de pago
+					agregarRetencionesComoMediosPagos(pagos, hdr);
+				} else {
+					// En OP adelantada no se deben aplicar retenciones.
+					m_retenciones.clear();
+					retencionIncludedInMedioPago = false;
+				}
 				// Agrego los medios de pagos al generador
 				for (MedioPago pago : pagos) {
 					pago.addToGenerator(getPoGenerator());
@@ -3198,6 +3212,14 @@ public class VOrdenPagoModel {
 
 	public boolean isNormalPayment() {
 		return m_esPagoNormal;
+	}
+	
+	/**
+	 * Define si el flujo actual debe administrar retenciones.
+	 * En OP adelantada no se calculan ni se generan.
+	 */
+	protected boolean shouldManageRetentionsInCurrentPayment() {
+		return m_esPagoNormal || isSOTrx();
 	}
 
 	public Properties getCtx() {


### PR DESCRIPTION
OP#7098
Se corrige la OP adelantada para que no calcule ni genere retenciones; estas quedan para la OP definitiva al asignar.

Adicionalmente se documenta en AGENTS.md/CLAUDE.md que los agentes no deben ejecutar compilaciones (`Compilar.sh`/`ant`) y se ignora `.codex` en `.gitignore`.