### PR TITLE
OP#7097 Corregir cálculo de retenciones con NC en Orden de Pago

### DIFF
--- a/base/src/org/openXpertya/model/AbstractRetencionProcessor.java
+++ b/base/src/org/openXpertya/model/AbstractRetencionProcessor.java
@@ -743,12 +743,12 @@ public abstract class AbstractRetencionProcessor implements RetencionProcessor {
 			}
 		}
 		
-		// dREHER 20 Feb 2026
-		// si existe neto de NC, lo resto del total a considerar para el calculo de retencion, ya que el mismo NO debe computarse como monto imputado
-		
-		debug("Descuento del total el neto de NC. total antes:" + netTotal + " netoNC:" + getNetAmountNC());
-		
-		netTotal = netTotal.subtract(getNetAmountNC());
+		// El neto de NC sólo corresponde al pago actual.
+		// No debe afectar el cálculo de pagos anteriores.
+		if (!isAnterior) {
+			debug("Descuento del total el neto de NC. total antes:" + netTotal + " netoNC:" + getNetAmountNC());
+			netTotal = netTotal.subtract(getNetAmountNC());
+		}
 		
 		return netTotal;
 	}

--- a/base/src/org/openXpertya/process/RetencionFacturasMGanancias.java
+++ b/base/src/org/openXpertya/process/RetencionFacturasMGanancias.java
@@ -128,10 +128,6 @@ public class RetencionFacturasMGanancias extends AbstractRetencionProcessor {
 		// se asigna la base imponible a cero.
 		baseImponible = (baseImponible.compareTo(Env.ZERO) < 0 ? Env.ZERO : estePago);
 		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-		
 		// Se calcula el importe determinado.
 		// ID = BI * T / 100
 		importeDeterminado = baseImponible.multiply(getPorcentajeRetencion()).divide(Env.ONEHUNDRED, 2, BigDecimal.ROUND_HALF_EVEN);

--- a/base/src/org/openXpertya/process/RetencionFacturasMIva.java
+++ b/base/src/org/openXpertya/process/RetencionFacturasMIva.java
@@ -125,11 +125,6 @@ public class RetencionFacturasMIva extends AbstractRetencionProcessor {
 		// BI = EP - INI 
 		baseImponible = estePago.subtract(getImporteNoImponible());
 		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-		
-		
 		// Si la base imponible es menor que cero, entonces no hay retención que aplicar y
 		// se asigna la base imponible a cero.
 		importeDeterminado = calculateImporteDeterminado(baseImponible, estePago);

--- a/base/src/org/openXpertya/process/RetencionGanancias.java
+++ b/base/src/org/openXpertya/process/RetencionGanancias.java
@@ -162,10 +162,6 @@ public class RetencionGanancias extends AbstractRetencionProcessor {
 		baseImponible = PPA.add(PNA).subtract(
 				INI);
 		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-		
 		debug("baseImponible antes de quitar ganancias de otros esquemas= " + baseImponible);
 		
 		// dREHER Marzo 25

--- a/base/src/org/openXpertya/process/RetencionHonorariosProfesionales.java
+++ b/base/src/org/openXpertya/process/RetencionHonorariosProfesionales.java
@@ -96,10 +96,6 @@ public class RetencionHonorariosProfesionales extends AbstractRetencionProcessor
 		baseImponible = baseImponible.subtract(RNL);
 		
 		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-		
 		debug("baseImponible despues de quitar ganancias de otros esquemas= " + baseImponible);
 		
 		// Si la base imponible es menor que cero, entonces no hay retención que aplicar y

--- a/base/src/org/openXpertya/process/RetencionIIBB.java
+++ b/base/src/org/openXpertya/process/RetencionIIBB.java
@@ -157,12 +157,6 @@ public class RetencionIIBB extends AbstractRetencionProcessor {
 		
 		baseImponible = baseImponible.subtract(descuentoNeto);
 		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-		
-		
-		
 		BigDecimal porcentajeRetencion = getPorcentajePadron(getPadrones(), getPorcentajeRetencionDefault());
 		
 		/*

--- a/base/src/org/openXpertya/process/RetencionIIBBTucuman.java
+++ b/base/src/org/openXpertya/process/RetencionIIBBTucuman.java
@@ -93,10 +93,6 @@ public class RetencionIIBBTucuman extends RetencionIIBBForRegion {
 						baseImponible = getPayNetAmt();
 					}
 					
-					// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-					baseImponible = baseImponible.subtract(getNetAmountNC());
-					debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-					
 					// Si hay base para calcular respecto al mínimo
 					if(baseImponible.compareTo(getMinimumNetAmt()) > 0) {
 						// Consultar con el padrón de coeficientes
@@ -158,10 +154,6 @@ public class RetencionIIBBTucuman extends RetencionIIBBForRegion {
 						baseImponible = getPayNetAmt();
 					}
 					
-					// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-					baseImponible = baseImponible.subtract(getNetAmountNC());
-					debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-					
 					// Si hay base para calcular respecto al mínimo
 					if(baseImponible.compareTo(getMinimumNetAmt()) > 0) {
 						// Consultar con el padrón de coeficientes
@@ -200,10 +192,6 @@ public class RetencionIIBBTucuman extends RetencionIIBBForRegion {
 				porcentajeTucuman = porcentajeTucuman == null? BigDecimal.ZERO: porcentajeTucuman;
 				baseImponible = getPayNetAmt();
 				
-				// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-				baseImponible = baseImponible.subtract(getNetAmountNC());
-				debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
-				
 				if(baseImponible.compareTo(getMinimumNetAmt()) > 0) {
 					baseImponible = baseImponible.multiply(porcentajeTucuman).divide(Env.ONEHUNDRED, 2,
 							BigDecimal.ROUND_HALF_EVEN);
@@ -233,10 +221,6 @@ public class RetencionIIBBTucuman extends RetencionIIBBForRegion {
 	 */
 	private BigDecimal applyPercentAndSave(BigDecimal baseImponible, BigDecimal percentage, BigDecimal compareMinimumAmt) {
 		BigDecimal ir = BigDecimal.ZERO;
-		
-		// dREHER Feb 26 descuento las NC que se cargaron en la OP 
-		baseImponible = baseImponible.subtract(getNetAmountNC());
-		debug("baseImponible despues de quitar monto neto de NC= " + baseImponible);
 		
 		compareMinimumAmt = compareMinimumAmt == null?baseImponible:compareMinimumAmt;
 		if(compareMinimumAmt.compareTo(getMinimumNetAmt()) > 0) {

--- a/client/Src/org/openXpertya/apps/form/VOrdenPago.java
+++ b/client/Src/org/openXpertya/apps/form/VOrdenPago.java
@@ -1542,8 +1542,9 @@ public class VOrdenPago extends CPanel implements FormPanel,ActionListener,Table
 	    			totalCredito = totalCredito.add(unMP.getImporte());
 	    		}
 	    		
-	    		debug("Asigno al modelo el total de los medios de pago de crédito: " + totalCredito);
-	    		m_model.setNetAmountNC(totalCredito);
+	    		debug("Total de créditos agregados en esta operación: " + totalCredito);
+	    		m_model.recalculateNetAmountNCFromCredits();
+	    		debug("Asigno al modelo el neto de NC considerando todos los créditos actuales: " + m_model.getNetAmountNC());
 	    		
 	    		debug("Recalculo retenciones luego de asignar el total de los medios de pago de crédito al modelo");
 	    		m_model.m_retenciones.clear();

--- a/client/Src/org/openXpertya/apps/form/VOrdenPagoModel.java
+++ b/client/Src/org/openXpertya/apps/form/VOrdenPagoModel.java
@@ -3641,11 +3641,13 @@ public class VOrdenPagoModel {
 
 	public void addMedioPago(MedioPago mp) {
 		m_mediosPago.add(mp);
+		recalculateNetAmountNCFromCredits();
 		updateAddingMedioPago(mp);
 	}
 
 	public void removeMedioPago(MedioPago mp) {
 		m_mediosPago.remove(mp);
+		recalculateNetAmountNCFromCredits();
 		updateRemovingMedioPago(mp);
 	}
 
@@ -4046,6 +4048,7 @@ public class VOrdenPagoModel {
 		m_mediosPago = new Vector<MedioPago>();
 		m_retGen = null;
 		m_retenciones = new Vector<RetencionProcessor>();
+		netAmountNC = BigDecimal.ZERO;
 		mpayments = new HashMap<Integer, MPayment>();
 		mCashLines = new HashMap<Integer, MCashLine>();
 		aditionalWorkResults = new HashMap<PO, Object>();
@@ -4502,7 +4505,20 @@ public class VOrdenPagoModel {
 		this.isFacturaProveedorTasaCambioInterna = isFacturaProveedorTasaCambioInterna;
 	}
 
+	public void recalculateNetAmountNCFromCredits() {
+		BigDecimal total = BigDecimal.ZERO;
+		for (MedioPago medioPago : m_mediosPago) {
+			if (MedioPago.TIPOMEDIOPAGO_CREDITO.equals(medioPago.getTipoMP())) {
+				total = total.add(medioPago.getImporte());
+			}
+		}
+		setNetAmountNC(total);
+	}
+
 	public BigDecimal getNetAmountNC() {
+		if (netAmountNC == null) {
+			netAmountNC = BigDecimal.ZERO;
+		}
 		return netAmountNC;
 	}
 


### PR DESCRIPTION
OP#7097
Corrige el cálculo de retenciones en OP cuando hay NC/anticipos, evitando doble descuento del neto NC y reseteando/recalculando correctamente `netAmountNC` para que no se arrastre entre operaciones.