### PR TITLE
OP#7730 Validar provincia al guardar remitos

### DIFF
--- a/base/src/org/openXpertya/model/MInOut.java
+++ b/base/src/org/openXpertya/model/MInOut.java
@@ -1395,18 +1395,23 @@ public class MInOut extends X_M_InOut implements DocAction {
         
 		//Guardado auxiliar de datos para la impresion del documento.
 		if(!isProcessed()) {
-		       	MBPartner aBPartner = new MBPartner(getCtx(), getC_BPartner_ID(), get_TrxName());
-		       	MBPartnerLocation location = new MBPartnerLocation(getCtx(),	getC_BPartner_Location_ID(), get_TrxName());
-		       	MLocation loc = location.getLocation(false);
-		       	
-		       	String fullLocation = location.getLocation(true).toString();
-		       	setNombreCli(aBPartner.getName());
-		       	setNroIdentificCliente(aBPartner.getTaxID());
-		       	setDireccion(loc.getAddress1());
-		       	setLocalidad(loc.getCity());
-		       	setprovincia(loc.getRegion().getName());
-		       	setCP(loc.getPostal());
-		       	setCAT_Iva_ID(aBPartner.getC_Categoria_Iva_ID());
+			MBPartner aBPartner = new MBPartner(getCtx(), getC_BPartner_ID(), get_TrxName());
+			MBPartnerLocation location = new MBPartnerLocation(getCtx(), getC_BPartner_Location_ID(), get_TrxName());
+			MLocation loc = location.getLocation(false);
+			MRegion region = loc.getRegion();
+			if (loc.getCountry().isHasRegion() && region == null) {
+				log.saveError("FillMandatory", Msg.translate(getCtx(), "C_Region_ID"));
+				return false;
+			}
+
+			String fullLocation = location.getLocation(true).toString();
+			setNombreCli(aBPartner.getName());
+			setNroIdentificCliente(aBPartner.getTaxID());
+			setDireccion(loc.getAddress1());
+			setLocalidad(loc.getCity());
+			setprovincia(region != null ? region.getName() : loc.getRegionName());
+			setCP(loc.getPostal());
+			setCAT_Iva_ID(aBPartner.getC_Categoria_Iva_ID());
 		}
 		
         return true;


### PR DESCRIPTION
OP#7730

## Resumen
- Valida que la dirección de la entidad comercial tenga provincia cuando el país utiliza regiones.
- Evita el `NullPointerException` al guardar un remito con una dirección incompleta.
- Conserva el nombre libre de región para países que no utilizan regiones configuradas.

## Causa raíz
`MInOut.beforeSave()` invocaba `loc.getRegion().getName()` sin contemplar que `C_Region_ID` puede estar vacío.

## Pruebas
- Prueba funcional manual confirmada: el remito muestra el mensaje de provincia obligatoria y no genera el NPE.
- `git diff --check` sin errores.
- No se ejecutó compilación ni Ant por la política del repositorio.