### PR TITLE
OP#7803 Corregir códigos promocionales en TPV

### DIFF
--- a/base/src/org/openXpertya/model/DiscountCalculator.java
+++ b/base/src/org/openXpertya/model/DiscountCalculator.java
@@ -2580,9 +2580,22 @@ public class DiscountCalculator {
 			result.setMsg(Msg.getMsg(getCtx(), "PromotionalCodeAlreadyLoaded"), true);
 			return result;
 		}
+		// La configuración de descuentos es necesaria para determinar la cantidad
+		// máxima de cupones promocionales permitidos.
+		if(!hasDiscountConfig()){
+			result.setMsg(Msg.parseTranslation(getCtx(), "@NotFound@: @M_DiscountConfig_ID@"), true);
+			return result;
+		}
 		// Verificar en la config de descuentos cuantos se pueden aplicar maximo
 		if(getDiscountConfig().getMaxPromotionalCoupons() <= getPromotionalCodes().size()){
 			result.setMsg(Msg.getMsg(getCtx(), "PromotionalCodeSurpassMaxConfig"), true);
+			return result;
+		}
+		// La aplicación de promociones debe formar parte de la configuración de
+		// descuentos a nivel de línea.
+		if(!getDiscountConfig().getLineDiscountsList().contains(MDiscountConfig.DISCOUNT_Promotion)){
+			result.setMsg(Msg.getMsg(getCtx(), "InvalidLevelDiscountConfig",
+					new Object[] { Msg.translate(getCtx(), "Line") }), true);
 			return result;
 		}
 		// Verificar si el código existe y no fue usado, si es así, controlar

--- a/client/Src/org/openXpertya/pos/model/Order.java
+++ b/client/Src/org/openXpertya/pos/model/Order.java
@@ -1248,6 +1248,9 @@ public class Order  {
 
 	public void setOrganization(Organization organization) {
 		this.organization = organization;
+		if(organization != null && getDiscountCalculator() != null){
+			getDiscountCalculator().setDiscountConfig(organization.getId());
+		}
 	}
 
 	public Integer getCreditPOSPaymentMediumID() {

--- a/client/Src/org/openXpertya/pos/view/PromotionsDialog.java
+++ b/client/Src/org/openXpertya/pos/view/PromotionsDialog.java
@@ -21,6 +21,7 @@ import org.compiere.swing.CButton;
 import org.compiere.swing.CPanel;
 import org.compiere.swing.CScrollPane;
 import org.compiere.swing.CTextField;
+import org.openXpertya.apps.ADialog;
 import org.openXpertya.minigrid.MiniTable;
 import org.openXpertya.pos.model.Promotion;
 import org.openXpertya.pos.view.table.PromotionTableModel;
@@ -242,9 +243,7 @@ public class PromotionsDialog extends JDialog {
 			cOKButton.setPreferredSize(new java.awt.Dimension(BUTTON_WIDTH,26));
 			cOKButton.addActionListener(new java.awt.event.ActionListener() {
 				public void actionPerformed(java.awt.event.ActionEvent e) {
-					// Actualiza descuentos y sale de la ventana
-					getPoS().getModel().getOrder().updateDiscounts();
-					exit();
+					confirm();
 				}
 			});
 			
@@ -294,21 +293,22 @@ public class PromotionsDialog extends JDialog {
 	 * validaciones
 	 * 
 	 * @param code código promocional
+	 * @return true si el código se agregó, false si no superó las validaciones
 	 */
-	protected void addPromotionalCode(String code){
+	protected boolean addPromotionalCode(String code){
 		if(Util.isEmpty(code, true))
-			return;
+			return false;
 
 		// Validar que no exista un medio de cobro ya cargado
 		if(getPoS().getModel().getOrder().getPayments().size() > 0){
 			errorMsg(MSG_ALREADY_EXISTS_PAYMENT_MEDIUM);
-			return;
+			return false;
 		}
 		// Validar que exista una promo vigente para ese código
 		CallResult result = getPoS().getModel().isPromotionalCodeValid(code);
 		if(result.isError()){
 			errorMsg(result.getMsg());
-			return;
+			return false;
 		}
 		// Agregar el código promocional y reaplicar los descuentos/recargos
 		getPoS().getModel().addPromotionalCode(code);
@@ -318,9 +318,18 @@ public class PromotionsDialog extends JDialog {
 		
 		// Resetear el campo de código y refrescar la tabla
 		getCPromotionalCode().setValue(null);
-		((PromotionTableModel) getCPromotionsTable().getModel()).setPromotions(getPoS().getModel().getPromotions());
-		getPromotionsTableUtil().refreshTable();
-		// Salir de la ventana??
+		refreshPromotionsTable();
+		return true;
+	}
+
+	private void confirm(){
+		String code = (String)getCPromotionalCode().getValue();
+		if(!Util.isEmpty(code, true) && !addPromotionalCode(code)){
+			return;
+		}
+		// Actualiza descuentos y sale de la ventana
+		getPoS().getModel().getOrder().updateDiscounts();
+		exit();
 	}
 	
 	protected void removePromotionalCode(Object selectedPromotion){
@@ -333,9 +342,7 @@ public class PromotionsDialog extends JDialog {
 				getPoS().getModel().removePromotionalCode(promo.getCode());
 				// Refrescar la tabla del pedido
 				getPoS().refreshOrderProductsTable();
-				((PromotionTableModel) getCPromotionsTable().getModel())
-						.setPromotions(getPoS().getModel().getPromotions());
-				getPromotionsTableUtil().refreshTable();
+				refreshPromotionsTable();
 			}
 		}
 		else{
@@ -343,6 +350,13 @@ public class PromotionsDialog extends JDialog {
 			// código promocional
 			errorMsg(MSG_DELETE_NOT_ALLOWED);
 		}
+	}
+
+	private void refreshPromotionsTable(){
+		PromotionTableModel tableModel = (PromotionTableModel)getCPromotionsTable().getModel();
+		tableModel.setPromotions(getPoS().getModel().getPromotions());
+		tableModel.fireTableDataChanged();
+		getPromotionsTableUtil().refreshTable();
 	}
 	
 	private void setActionEnabled(String action, KeyStroke ks, boolean enabled) {
@@ -388,7 +402,7 @@ public class PromotionsDialog extends JDialog {
 	}
 	
 	private void errorMsg(String msg, String subMsg) {
-		getPoS().errorMsg(msg,subMsg);
+		ADialog.error(getPoS().getWindowNo(), this, msg, subMsg);
 		
 	}
 	


### PR DESCRIPTION
OP#7803
Corrige la carga, validación y aplicación de códigos promocionales en TPV.

- Procesa el código pendiente tanto con Enter como con F12.
- Mantiene abierto el diálogo y muestra los errores de validación sobre la ventana activa.
- Valida la configuración de descuentos y la selecciona según la organización del TPV.
- Refresca la grilla de promociones después de agregar o eliminar un código.

Pruebas:
- Prueba funcional manual confirmada en TPV con código válido e inexistente.
- `git diff --check` sin errores.
- Compilación ejecutada manualmente por el usuario.