### PR TITLE
OP#7737 Permitir servicios repetidos en pedidos a proveedor

### DIFF
--- a/base/src/org/openXpertya/model/MClientInfo.java
+++ b/base/src/org/openXpertya/model/MClientInfo.java
@@ -53,6 +53,9 @@ public class MClientInfo extends X_AD_ClientInfo {
     /** Logger */
     private static CLogger	s_log	= CLogger.getCLogger(MClientInfo.class);
 
+    /** Permite repetir servicios en documentos */
+    private static final String COLUMNNAME_ALLOW_DUPLICATE_SERVICE = "AllowDuplicateService";
+
     /** Account Schema */
     private MAcctSchema	m_acctSchema	= null;
 
@@ -136,6 +139,27 @@ public class MClientInfo extends X_AD_ClientInfo {
         return saveUpdate();
 
     }		// save
+
+    /**
+     * @return true si la compania permite repetir articulos de tipo servicio en
+     *         pedidos a proveedor.
+     */
+    public boolean isAllowDuplicateService() {
+        int index = get_ColumnIndexIgnoreCase(COLUMNNAME_ALLOW_DUPLICATE_SERVICE);
+        if(index < 0) {
+            return false;
+        }
+
+        Object value = get_Value(index);
+        if(value != null) {
+            if(value instanceof Boolean) {
+                return ((Boolean)value).booleanValue();
+            }
+            return "Y".equals(value);
+        }
+
+        return false;
+    }
     
     @Override
     protected boolean afterSave(boolean newRecord, boolean success) {

--- a/base/src/org/openXpertya/model/MOrderLine.java
+++ b/base/src/org/openXpertya/model/MOrderLine.java
@@ -758,6 +758,7 @@ public class MOrderLine extends X_C_OrderLine {
 	        	String whereClause = "c_order_id = ? AND m_product_id = ?";
 	        	whereClause += newRecord?"":" AND c_orderline_id <> "+getC_OrderLine_ID();
 				if (MDocType.DOCTYPE_PurchaseOrder.equals(orderDocType.getDocTypeKey())
+						&& !isDuplicateServiceInPurchaseOrderAllowed()
 						&& PO.existRecordFor(getCtx(), get_TableName(),
 								whereClause, new Object[] { getC_Order_ID(), getM_Product_ID() },
 								get_TrxName())) {
@@ -984,6 +985,27 @@ public class MOrderLine extends X_C_OrderLine {
         
         return true;
     }    // beforeSave
+
+    /**
+     * @return true si la compania permite repetir este servicio en pedidos a
+     *         proveedor.
+     */
+    private boolean isDuplicateServiceInPurchaseOrderAllowed() {
+        if(!isServiceProduct()) {
+            return false;
+        }
+
+        MClientInfo clientInfo = MClientInfo.get(getCtx(), getAD_Client_ID(), get_TrxName());
+        return clientInfo != null && clientInfo.isAllowDuplicateService();
+    }
+
+    /**
+     * @return true si el producto de la linea es de tipo servicio.
+     */
+    private boolean isServiceProduct() {
+        MProduct product = getProduct();
+        return product != null && MProduct.PRODUCTTYPE_Service.equals(product.getProductType());
+    }
 
     
     /**

--- a/data/core/upgrade_from_26.05/preinstall_from_26.05.sql
+++ b/data/core/upgrade_from_26.05/preinstall_from_26.05.sql
@@ -124,3 +124,7 @@ FROM ad_table t
 WHERE t.ad_table_id = tt.ad_table_id
   AND t.ad_componentobjectuid = 'CORE-AD_Table-203'
   AND tt.ad_language ILIKE 'es_%';
+
+-- 20260626-1208 Configuracion para permitir servicios repetidos en pedidos a proveedor
+update ad_system set dummy = (SELECT addcolumnifnotexists('AD_ClientInfo','AllowDuplicateService','character(1) NOT NULL DEFAULT ''N''::bpchar'));
+UPDATE AD_ClientInfo SET AllowDuplicateService = 'N' WHERE AllowDuplicateService IS NULL;


### PR DESCRIPTION
OP#7737

Permite configurar por compania si se aceptan multiples lineas con el mismo articulo de tipo servicio en pedidos a proveedor.

Validacion:
- Prueba funcional confirmada por el usuario en ly_core_test.
- git diff --check --cached antes del commit.

Nota:
- No se ejecuto compilacion del proyecto desde el agente, segun las reglas del repositorio.